### PR TITLE
updated upstream repo location (name change from kickstart to quickstart

### DIFF
--- a/deploy/helm/rag/Chart.lock
+++ b/deploy/helm/rag/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: llm-service
-  repository: https://rh-ai-kickstart.github.io/ai-architecture-charts
+  repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   version: 0.1.0
 - name: llama-stack
-  repository: https://rh-ai-kickstart.github.io/ai-architecture-charts
+  repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   version: 0.2.9
 - name: pgvector
-  repository: https://rh-ai-kickstart.github.io/ai-architecture-charts
+  repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   version: 0.1.0
-digest: sha256:f492dc5f61f7935bbdd9ff8626b6a0be36738e5d37277e64783b166f6433a1e0
-generated: "2025-06-30T11:46:23.027461822+03:00"
+digest: sha256:10c28892279053261ef73650b2d36b170ab8e3662c76cd9638b1908fe781899d
+generated: "2025-08-26T17:45:41.258315-04:00"

--- a/deploy/helm/rag/Chart.yaml
+++ b/deploy/helm/rag/Chart.yaml
@@ -8,10 +8,10 @@ appVersion: "1.16.0"
 dependencies:
   - name: llm-service
     version: 0.1.0
-    repository: https://rh-ai-kickstart.github.io/ai-architecture-charts
+    repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   - name: llama-stack
     version: 0.2.9
-    repository: https://rh-ai-kickstart.github.io/ai-architecture-charts
+    repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   - name: pgvector
     version: 0.1.0
-    repository: https://rh-ai-kickstart.github.io/ai-architecture-charts  
+    repository: https://rh-ai-quickstart.github.io/ai-architecture-charts


### PR DESCRIPTION
## Changes

Upstream repo location changed from `kickstart` to `quickstart`

## Checklist

- [x] Verify on the cluster
- [ ] Update tests if applicable and run `pytest`
- [x] Add screenshots (if applicable)
- [ ] Update readme (if applicable)


## Screenshots

* Successful run of `make install` run locally:
<img width="1777" height="1088" alt="make_install-01" src="https://github.com/user-attachments/assets/945f5388-b322-42b9-af42-5f24218e06bf" />
<img width="1793" height="260" alt="make_install-02" src="https://github.com/user-attachments/assets/46cfd049-a2f2-49c4-b0aa-081bd25e7d2b" />
