### PR TITLE
feat: [APPENG-3503] MCP Transition - OpenShift Metric: add analyze-openshift tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.cursor
 .vscode
 .idea
 # Byte-compiled / optimized / DLL files

--- a/src/core/metrics.py
+++ b/src/core/metrics.py
@@ -14,6 +14,10 @@ from datetime import datetime
 from typing import List, Dict, Any, Optional
 
 from .config import PROMETHEUS_URL, THANOS_TOKEN, VERIFY_SSL
+from fastapi import HTTPException
+from .llm_client import summarize_with_llm
+from .response_validator import ResponseType
+from .llm_client import build_openshift_prompt
 
 
 def get_models_helper() -> List[str]:
@@ -580,6 +584,84 @@ def get_namespace_specific_metrics(category):
     }
 
     return namespace_aware_metrics.get(category, {})
+
+
+def analyze_openshift_metrics(
+    metric_category: str,
+    scope: str,
+    namespace: Optional[str],
+    start_ts: int,
+    end_ts: int,
+    summarize_model_id: Optional[str],
+    api_key: Optional[str],
+) -> Dict[str, Any]:
+    """Core analyze-openshift logic extracted from API.
+
+    Returns a dict matching the API response fields (health_prompt, llm_summary, metrics, etc.).
+    Raises HTTPException for client (400) and server (500) errors.
+    """
+    try:
+        openshift_metrics = get_openshift_metrics()
+
+        # Validate metric category based on scope
+        if scope == "namespace_scoped" and namespace:
+            namespace_metrics = get_namespace_specific_metrics(metric_category)
+            if not namespace_metrics:
+                if metric_category not in openshift_metrics:
+                    raise HTTPException(status_code=400, detail=f"Invalid metric category: {metric_category}")
+                metrics_to_fetch = openshift_metrics[metric_category]
+            else:
+                metrics_to_fetch = namespace_metrics
+        else:
+            if metric_category not in openshift_metrics:
+                raise HTTPException(status_code=400, detail=f"Invalid metric category: {metric_category}")
+            metrics_to_fetch = openshift_metrics[metric_category]
+
+        namespace_for_query = namespace if scope == "namespace_scoped" else None
+
+        # Fetch metrics
+        metric_dfs: Dict[str, Any] = {}
+        for label, query in metrics_to_fetch.items():
+            try:
+                df = fetch_openshift_metrics(query, start_ts, end_ts, namespace_for_query)
+                metric_dfs[label] = df
+            except Exception:
+                metric_dfs[label] = pd.DataFrame()
+
+        # Build scope description
+        scope_description = f"{scope.replace('_', ' ').title()}"
+        if scope == "namespace_scoped" and namespace:
+            scope_description += f" ({namespace})"
+
+        # Build OpenShift metrics prompt and summarize
+        prompt = build_openshift_prompt(
+            metric_dfs, metric_category, namespace_for_query, scope_description
+        )
+        summary = summarize_with_llm(
+            prompt, summarize_model_id or "", ResponseType.OPENSHIFT_ANALYSIS, api_key or ""
+        )
+
+        # Serialize metric DataFrames
+        serialized_metrics: Dict[str, Any] = {}
+        for label, df in metric_dfs.items():
+            if "timestamp" not in df.columns:
+                df["timestamp"] = pd.Series(dtype="datetime64[ns]")
+            if "value" not in df.columns:
+                df["value"] = pd.Series(dtype="float")
+            serialized_metrics[label] = df[["timestamp", "value"]].to_dict(orient="records")
+
+        return {
+            "metric_category": metric_category,
+            "scope": scope,
+            "namespace": namespace,
+            "health_prompt": prompt,
+            "llm_summary": summary,
+            "metrics": serialized_metrics,
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
 
 
 # --- Metric Fetching Functions ---

--- a/src/core/metrics.py
+++ b/src/core/metrics.py
@@ -19,6 +19,7 @@ from .llm_client import summarize_with_llm
 from .response_validator import ResponseType
 from .llm_client import build_openshift_prompt
 NAMESPACE_SCOPED = "namespace_scoped"
+CLUSTER_WIDE = "cluster_wide"
 
 
 

--- a/src/core/metrics.py
+++ b/src/core/metrics.py
@@ -598,8 +598,7 @@ def analyze_openshift_metrics(
     summarize_model_id: Optional[str],
     api_key: Optional[str],
 ) -> Dict[str, Any]:
-    """Core analyze-openshift logic extracted from API.
-
+    """
     Returns a dict matching the API response fields (health_prompt, llm_summary, metrics, etc.).
     Raises HTTPException for client (400) and server (500) errors.
     """

--- a/src/core/metrics.py
+++ b/src/core/metrics.py
@@ -18,6 +18,8 @@ from fastapi import HTTPException
 from .llm_client import summarize_with_llm
 from .response_validator import ResponseType
 from .llm_client import build_openshift_prompt
+NAMESPACE_SCOPED = "namespace_scoped"
+
 
 
 def get_models_helper() -> List[str]:
@@ -604,7 +606,7 @@ def analyze_openshift_metrics(
         openshift_metrics = get_openshift_metrics()
 
         # Validate metric category based on scope
-        if scope == "namespace_scoped" and namespace:
+        if scope == NAMESPACE_SCOPED and namespace:
             namespace_metrics = get_namespace_specific_metrics(metric_category)
             if not namespace_metrics:
                 if metric_category not in openshift_metrics:
@@ -617,7 +619,7 @@ def analyze_openshift_metrics(
                 raise HTTPException(status_code=400, detail=f"Invalid metric category: {metric_category}")
             metrics_to_fetch = openshift_metrics[metric_category]
 
-        namespace_for_query = namespace if scope == "namespace_scoped" else None
+        namespace_for_query = namespace if scope == NAMESPACE_SCOPED else None
 
         # Fetch metrics
         metric_dfs: Dict[str, Any] = {}
@@ -630,7 +632,7 @@ def analyze_openshift_metrics(
 
         # Build scope description
         scope_description = f"{scope.replace('_', ' ').title()}"
-        if scope == "namespace_scoped" and namespace:
+        if scope == NAMESPACE_SCOPED and namespace:
             scope_description += f" ({namespace})"
 
         # Build OpenShift metrics prompt and summarize

--- a/src/mcp_server/README.md
+++ b/src/mcp_server/README.md
@@ -10,6 +10,7 @@ The MCP server provides the following tools:
 - **`list_namespaces`** - List monitored Kubernetes namespaces with observability data
 - **`get_model_config`** - Get available LLM models for summarization and analysis
 - **`analyze_vllm`** - Analyze vLLM metrics for a model and summarize with an LLM
+- **`analyze_openshift`** - Analyze OpenShift metrics by category and scope, returning an LLM summary
 
 ## 📋 Prerequisites
 
@@ -173,6 +174,7 @@ Troubleshooting tips:
 | `list_namespaces` | Lists monitored Kubernetes namespaces | Sorted list of namespace names |
 | `get_model_config` | Gets LLM models for summarization | Internal/external model configurations |
 | `analyze_vllm` |  fetch metrics, build prompt, summarize | Text summary with prompt and metrics preview |
+| `analyze_openshift` | Analyze metrics for a given category/scope | Text block with LLM summary and context |
 
 The vLLM discovery tools query Prometheus metrics using identical logic as the main metrics API. The model config tool reads environment configuration for LLM models. 
 

--- a/src/mcp_server/mcp.py
+++ b/src/mcp_server/mcp.py
@@ -22,10 +22,12 @@ class ObservabilityMCPServer:
             list_namespaces,
             get_model_config,
             analyze_vllm,
+            analyze_openshift,
         )
 
         self.mcp.tool()(list_models)
         self.mcp.tool()(list_namespaces)
         self.mcp.tool()(get_model_config)
         self.mcp.tool()(analyze_vllm)
+        self.mcp.tool()(analyze_openshift)
 

--- a/src/mcp_server/setup_integration.py
+++ b/src/mcp_server/setup_integration.py
@@ -126,13 +126,15 @@ def generate_claude_config(mcp_stdio_path: str) -> Dict[str, Any]:
                     "list_models",
                     "list_namespaces",
                     "get_model_config",
-                    "analyze_vllm"
+                    "analyze_vllm",
+                    "analyze_openshift"
                 ],
                 "alwaysAllow": [
                     "list_models", 
                     "list_namespaces",
                     "get_model_config",
-                    "analyze_vllm"
+                    "analyze_vllm",
+                    "analyze_openshift"
                 ],
                 "disabled": False
             }

--- a/src/mcp_server/tools/observability_tools.py
+++ b/src/mcp_server/tools/observability_tools.py
@@ -3,6 +3,8 @@
 This module provides MCP tools for interacting with OpenShift AI observability data:
 - list_models: Get available AI models
 - list_namespaces: List monitored namespaces
+- get_model_config: Show configured LLM models for summarization
+- analyze_openshift: Analyze OpenShift metrics by category/scope using API logic
 """
 
 import json
@@ -14,6 +16,8 @@ from core.metrics import get_models_helper, get_namespaces_helper, get_vllm_metr
 from core.llm_client import build_prompt, summarize_with_llm, extract_time_range_with_info
 from core.models import AnalyzeRequest
 from core.response_validator import ResponseType
+from api.metrics_api import analyze_openshift as _api_analyze_openshift
+from core.models import OpenShiftAnalyzeRequest
 from core.config import PROMETHEUS_URL, THANOS_TOKEN, VERIFY_SSL
 import requests
 from datetime import datetime
@@ -22,6 +26,39 @@ from datetime import datetime
 def _resp(content: str, is_error: bool = False) -> List[Dict[str, Any]]:
     """Helper to format MCP tool responses consistently."""
     return [{"type": "text", "text": content}]
+
+
+def resolve_time_range(
+    time_range: Optional[str] = None,
+    start_datetime: Optional[str] = None,
+    end_datetime: Optional[str] = None,
+) -> tuple[int, int]:
+    """Resolve various time inputs into start/end epoch seconds.
+
+    Precedence:
+    1) time_range natural language → use extract_time_range_with_info
+    2) ISO datetime strings (start_datetime/end_datetime)
+    3) Default to last 1 hour
+    """
+    try:
+        # 1) Natural language time range
+        if time_range:
+            start_ts, end_ts, _info = extract_time_range_with_info(time_range, None, None)
+            return start_ts, end_ts
+
+        # 2) ISO datetime strings
+        if start_datetime and end_datetime:
+            rs = int(datetime.fromisoformat(start_datetime.replace("Z", "+00:00")).timestamp())
+            re = int(datetime.fromisoformat(end_datetime.replace("Z", "+00:00")).timestamp())
+            return rs, re
+
+        # 3) Default: last 1 hour
+        now = int(datetime.utcnow().timestamp())
+        return now - 3600, now
+    except Exception:
+        # Safe fallback to last 1 hour on any parsing error
+        now = int(datetime.utcnow().timestamp())
+        return now - 3600, now
 
 
 def list_models() -> List[Dict[str, Any]]:
@@ -124,24 +161,12 @@ def analyze_vllm(
     and a compact metrics preview.
     """
     try:
-        # Resolve time range → start_ts/end_ts
-        # Resolve time range
-        if time_range:
-            # Natural language (e.g., "last 1h", "last 24h")
-            resolved_start, resolved_end, _info = extract_time_range_with_info(time_range, None, None)
-        elif start_datetime and end_datetime:
-            # ISO 8601 datetimes
-            try:
-                rs = int(datetime.fromisoformat(start_datetime.replace("Z", "+00:00")).timestamp())
-                re = int(datetime.fromisoformat(end_datetime.replace("Z", "+00:00")).timestamp())
-                resolved_start, resolved_end = rs, re
-            except Exception as e:
-                return _resp(f"Invalid ISO datetimes: {e}", is_error=True)
-        else:
-            # Default last 1 hour
-            now = int(datetime.utcnow().timestamp())
-            resolved_end = now
-            resolved_start = now - 3600
+        # Resolve time range → start_ts/end_ts via common helper
+        resolved_start, resolved_end = resolve_time_range(
+            time_range=time_range,
+            start_datetime=start_datetime,
+            end_datetime=end_datetime,
+        )
 
         # Collect metrics
         vllm_metrics = get_vllm_metrics()
@@ -181,3 +206,85 @@ def analyze_vllm(
         return _resp(content)
     except Exception as e:
         return _resp(f"Error during analysis: {str(e)}", is_error=True)
+
+def analyze_openshift(
+    metric_category: str,
+    scope: str = "cluster_wide",
+    namespace: Optional[str] = None,
+    time_range: Optional[str] = None,
+    start_datetime: Optional[str] = None,
+    end_datetime: Optional[str] = None,
+    summarize_model_id: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Analyze OpenShift metrics for a category and scope using the Metrics API logic.
+
+    Args:
+        metric_category: Must be one of the defined categories below.
+
+            Cluster-wide categories (valid for scope="cluster_wide"):
+            - "Fleet Overview"
+            - "Services & Networking"
+            - "Jobs & Workloads"
+            - "Storage & Config"
+            - "Workloads & Pods"
+            - "GPU & Accelerators"
+            - "Storage & Networking"
+            - "Application Services"
+
+            Namespace-scoped categories (valid for scope="namespace_scoped"):
+            - "Fleet Overview"
+            - "Workloads & Pods"
+            - "Compute & Resources"
+            - "Storage & Networking"
+            - "Application Services"
+
+            Tip: You can also retrieve these at runtime via the FastAPI endpoints
+            `/openshift-metric-groups` and `/openshift-namespace-metric-groups`.
+        scope: "cluster_wide" or "namespace_scoped"
+        namespace: required when scope == "namespace_scoped"
+        start_ts: unix epoch seconds (optional)
+        end_ts: unix epoch seconds (optional)
+        summarize_model_id: LLM model id to use for summary (optional)
+        api_key: API key for LLM provider (optional)
+
+    Returns:
+        A text block with the LLM summary and basic metadata.
+    """
+    try:
+        if scope not in ("cluster_wide", "namespace_scoped"):
+            return _resp("Invalid scope. Use 'cluster_wide' or 'namespace_scoped'.")
+        if scope == "namespace_scoped" and not namespace:
+            return _resp("Namespace is required when scope is 'namespace_scoped'.")
+
+        # Resolve time range uniformly (string inputs → epoch seconds)
+        start_ts, end_ts = resolve_time_range(
+            time_range=time_range,
+            start_datetime=start_datetime,
+            end_datetime=end_datetime,
+        )
+
+        req = OpenShiftAnalyzeRequest(
+            metric_category=metric_category,
+            scope=scope,
+            namespace=namespace or "",
+            start_ts=start_ts,
+            end_ts=end_ts,
+            summarize_model_id=summarize_model_id or os.getenv("DEFAULT_SUMMARIZE_MODEL", ""),
+            api_key=api_key or os.getenv("LLM_API_TOKEN", ""),
+        )
+
+        result = _api_analyze_openshift(req)  # Calls the FastAPI handler logic directly
+
+        # Format the response for MCP consumers
+        summary = result.get("llm_summary", "")
+        scope_desc = result.get("scope", scope)
+        ns_desc = result.get("namespace", namespace or "")
+        header = f"OpenShift Analysis ({metric_category}) — {scope_desc}"
+        if scope == "namespace_scoped" and ns_desc:
+            header += f" (namespace={ns_desc})"
+
+        content = f"{header}\n\n{summary}".strip()
+        return _resp(content)
+    except Exception as e:
+        return _resp(f"Error running analyze-openshift: {str(e)}", is_error=True)

--- a/src/mcp_server/tools/observability_tools.py
+++ b/src/mcp_server/tools/observability_tools.py
@@ -17,7 +17,7 @@ from core.metrics import get_models_helper, get_namespaces_helper, get_vllm_metr
 from core.llm_client import build_prompt, summarize_with_llm, extract_time_range_with_info
 from core.models import AnalyzeRequest
 from core.response_validator import ResponseType
-from core.metrics import analyze_openshift_metrics
+from core.metrics import analyze_openshift_metrics, NAMESPACE_SCOPED
 from core.config import PROMETHEUS_URL, THANOS_TOKEN, VERIFY_SSL
 import requests
 from datetime import datetime
@@ -249,9 +249,9 @@ def analyze_openshift(
         A text block with the LLM summary and basic metadata.
     """
     try:
-        if scope not in ("cluster_wide", "namespace_scoped"):
+        if scope not in ("cluster_wide", NAMESPACE_SCOPED):
             return _resp("Invalid scope. Use 'cluster_wide' or 'namespace_scoped'.")
-        if scope == "namespace_scoped" and not namespace:
+        if scope == NAMESPACE_SCOPED and not namespace:
             return _resp("Namespace is required when scope is 'namespace_scoped'.")
 
         # Resolve time range uniformly (string inputs → epoch seconds)
@@ -276,7 +276,7 @@ def analyze_openshift(
         scope_desc = result.get("scope", scope)
         ns_desc = result.get("namespace", namespace or "")
         header = f"OpenShift Analysis ({metric_category}) — {scope_desc}"
-        if scope == "namespace_scoped" and ns_desc:
+        if scope == NAMESPACE_SCOPED and ns_desc:
             header += f" (namespace={ns_desc})"
 
         content = f"{header}\n\n{summary}".strip()

--- a/src/mcp_server/tools/observability_tools.py
+++ b/src/mcp_server/tools/observability_tools.py
@@ -17,7 +17,7 @@ from core.metrics import get_models_helper, get_namespaces_helper, get_vllm_metr
 from core.llm_client import build_prompt, summarize_with_llm, extract_time_range_with_info
 from core.models import AnalyzeRequest
 from core.response_validator import ResponseType
-from core.metrics import analyze_openshift_metrics, NAMESPACE_SCOPED
+from core.metrics import analyze_openshift_metrics, NAMESPACE_SCOPED, CLUSTER_WIDE
 from core.config import PROMETHEUS_URL, THANOS_TOKEN, VERIFY_SSL
 import requests
 from datetime import datetime
@@ -249,7 +249,7 @@ def analyze_openshift(
         A text block with the LLM summary and basic metadata.
     """
     try:
-        if scope not in ("cluster_wide", NAMESPACE_SCOPED):
+        if scope not in (CLUSTER_WIDE, NAMESPACE_SCOPED):
             return _resp("Invalid scope. Use 'cluster_wide' or 'namespace_scoped'.")
         if scope == NAMESPACE_SCOPED and not namespace:
             return _resp("Namespace is required when scope is 'namespace_scoped'.")

--- a/src/mcp_server/tools/observability_tools.py
+++ b/src/mcp_server/tools/observability_tools.py
@@ -217,7 +217,7 @@ def analyze_openshift(
     summarize_model_id: Optional[str] = None,
     api_key: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
-    """Analyze OpenShift metrics for a category and scope using the Metrics API logic.
+    """Analyze OpenShift metrics for a category and scope.
 
     Args:
         metric_category: Must be one of the defined categories below.

--- a/tests/mcp_server/test_mcp.py
+++ b/tests/mcp_server/test_mcp.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 @patch("mcp_server.mcp.get_python_logger")
 @patch("mcp_server.mcp.force_reconfigure_all_loggers")
 @patch("fastmcp.FastMCP", autospec=True)
-def test_observability_mcp_server_registers_four_tools_and_reconfigures(
+def test_observability_mcp_server_registers_tools_and_reconfigures(
     MockFastMCP, mock_reconfigure, mock_get_logger
 ):
     # Arrange: create FastMCP instance mock and make tool() act like a decorator
@@ -28,7 +28,7 @@ def test_observability_mcp_server_registers_four_tools_and_reconfigures(
 
     # Assert
     assert server.mcp is mcp_instance
-    assert call_counter["count"] == 4  # four tools registered
+    assert call_counter["count"] == 5  # four tools registered
     mock_get_logger.assert_called_once()
     mock_reconfigure.assert_called_once()
 


### PR DESCRIPTION

## Changes
analyze_openshift tool — changes made

• Aligned time inputs with analyze_vllm
Added support for string-based time inputs: time_range, start_datetime, end_datetime.
Introduced a shared resolver resolve_time_range(...) to convert these into epoch (start_ts, end_ts).
• Implemented common time resolver
Precedence: time_range (natural language) → ISO datetimes → default last 1 hour.
Uses extract_time_range_with_info for natural language (e.g., “last 2h”).
• Refactored request construction
Replaced direct epoch handling with the resolved timestamps.
Builds OpenShiftAnalyzeRequest using the unified time resolution.
Calls existing FastAPI handler _api_analyze_openshift for analysis (reuses API logic).
• Output format
Returns a single MCP-friendly text response with a header (category/scope/namespace) and the LLM summary.
• Registration and configuration
Ensured the tool is registered in mcp.py.
Fixed setup configuration arrays (autoApprove, alwaysAllow) to include analyze_openshift.

Tested successfully with MCP Inspector.
<img width="1433" height="648" alt="Screenshot 2025-08-27 at 5 53 28 PM" src="https://github.com/user-attachments/assets/6b111ac7-405d-4d1f-8516-a3a2faa309b3" />

<img width="1412" height="648" alt="Screenshot 2025-08-27 at 5 54 06 PM" src="https://github.com/user-attachments/assets/4a1b63c2-d930-404a-9fb3-d15fff7c85b2" />
<img width="1442" height="653" alt="Screenshot 2025-08-27 at 5 54 30 PM" src="https://github.com/user-attachments/assets/43e37fd4-086c-4ef0-83a9-d9c2c7cca241" />


## Checklist

- [ ] Verify on the cluster
- [ ] Update tests if applicable and run `pytest`
- [X] Add screenshots (if applicable)
- [ ] Update readme (if applicable)