### PR TITLE
Changed uninstall to not remove observability components by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,6 @@ cython_debug/
 
 # log files
 src/api/log.txt
+
+# TMP directory (if any)
+TMP/


### PR DESCRIPTION
Improves the uninstall process for observability components by requiring explicit uninstall calls when removing these components from the system. This change addresses issues with the shared `observability-hub` namespace to prevent unintended removal of shared resources while still allowing intentional removal when needed.

## Changes
  * Before:
    * Observability components were automatically removed during uninstall, potentially affecting other teams using the shared observability-hub namespace.
  * After:
    * Default uninstall preserves shared observability infrastructure
    * Displays clear warning about skipped components
    * Requires explicit UNINSTALL_OBSERVABILITY=true flag to remove shared resources
    * Provides guidance on individual component removal commands


  ### Usage Examples

  * Standard Uninstall (Preserves Shared Observability)

     ```
      # Default behavior - preserves shared observability-hub namespace
      make uninstall NAMESPACE=my-app-namespace
     ```

  * Explicit Observability Uninstall

     ```
      # Removes observability components when explicitly requested
      make uninstall NAMESPACE=my-app-namespace UNINSTALL_OBSERVABILITY=true
     ```

  * Individual Component Removal
    * Remove only tracing from specific namespace
       ```
        make remove-tracing NAMESPACE=my-app-namespace
       ```
    * Remove observability stack entirely (affects all teams)
       ```
        make uninstall-observability
       ```
 
## Screenshots
- make install (skips already installed observability components):
<img width="1058" height="678" alt="make-install" src="https://github.com/user-attachments/assets/20954b87-dacc-4501-856f-7e9bcf557ce0" />

- make uninstall (does NOT uninstalls observability components):
<img width="887" height="712" alt="make-uninstall" src="https://github.com/user-attachments/assets/a1732869-f398-41ad-9e38-8734fd09badd" />

- make uninstall with `UNINSTALL_OBSERVABILITY=true` (uninstalls observability components):
<img width="977" height="637" alt="make-uninstall-02" src="https://github.com/user-attachments/assets/3d1ef41e-fca0-4386-9a54-1e45b9369265" />


## Checklist

- [x] Verify on the cluster
- [ ] Update tests if applicable and run `pytest`
- [x] Add screenshots (if applicable)
- [ ] Update readme (if applicable)