### PR TITLE
doing version update in "dev" branch only

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -205,7 +205,7 @@ jobs:
     name: Update versions in Helm charts and Makefile
     runs-on: ubuntu-latest
     needs: [semantic-version, build-image]
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'push' && github.ref_name == 'dev') || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -205,7 +205,7 @@ jobs:
     name: Update versions in Helm charts and Makefile
     runs-on: ubuntu-latest
     needs: [semantic-version, build-image]
-    if: (github.event_name == 'push' && github.ref_name == 'dev') || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'push' && github.ref_name != 'main') || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -31,10 +31,10 @@ The project uses 5 GitHub Actions workflows with the following execution order a
        - aiobs-metrics-ui
        - aiobs-metrics-alerting
        - aiobs-mcp-server
-     - Updates Helm charts and Makefile with new version (**`dev` branch only**)
+     - Updates Helm charts and Makefile with new version (**non-main branches only**)
    - **Image naming:** Semantic versions (e.g., `0.1.2`, `1.0.0`)
    - **Version priority:** PR Labels → PR Title → Commit Messages
-   - **Version updates:** _Only occur when pushing to `dev` branch_
+   - **Version updates:** _Only occur when pushing to non-main branches_
    - **Dependencies:** None - runs after merge
 
 4. **Deploy to OpenShift** (`.github/workflows/deploy.yml`)

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -26,13 +26,15 @@ The project uses 5 GitHub Actions workflows with the following execution order a
    - **Actions:** 
      - **Analyzes PR labels and title first**, then falls back to commit messages for version bumps
      - Gets current version from Makefile (not git tags)
-     - Builds 3 container images (using `IMAGE_PREFIX`-component naming):
+     - Builds 4 container images (using `IMAGE_PREFIX`-component naming):
        - aiobs-metrics-api
        - aiobs-metrics-ui
        - aiobs-metrics-alerting
-     - Updates Helm charts and Makefile with new version
+       - aiobs-mcp-server
+     - Updates Helm charts and Makefile with new version (**`dev` branch only**)
    - **Image naming:** Semantic versions (e.g., `0.1.2`, `1.0.0`)
    - **Version priority:** PR Labels → PR Title → Commit Messages
+   - **Version updates:** _Only occur when pushing to `dev` branch_
    - **Dependencies:** None - runs after merge
 
 4. **Deploy to OpenShift** (`.github/workflows/deploy.yml`)

--- a/docs/SEMANTIC_VERSIONING.md
+++ b/docs/SEMANTIC_VERSIONING.md
@@ -34,15 +34,18 @@ The workflow determines version bumps in this **order of priority**:
 ## How It Works
 
 1. **Trigger**: When PRs are merged to `main` or `dev` branches, or manually via `workflow_dispatch`
+   - **Version file updates**: Only occur when pushing to `dev` branch
+   - **Container builds**: Occur for both `main` and `dev` branches
 2. **Version calculation**: Analyzes PR labels and PR title **first**, then falls back to commit messages to determine bump type
 3. **Version increment**: Increments from the current version in Makefile (or starts from `0.1.1` if no version exists)
 4. **Container images**: Builds and pushes images to `quay.io/ecosystem-appeng/{IMAGE_PREFIX}-{component}:{version}` (e.g., `quay.io/ecosystem-appeng/aiobs-metrics-api:1.2.3`)
-5. **Auto-update**: Updates version in:
+5. **Auto-update**: Updates version files **only when pushing to `dev` branch**:
    - `deploy/helm/metrics-api/values.yaml`
    - `deploy/helm/ui/values.yaml` 
    - `deploy/helm/alerting/values.yaml`
+   - `deploy/helm/mcp-server/values.yaml`
    - `Makefile` VERSION variable
-6. **Git commit**: Commits version updates automatically
+6. **Git commit**: Commits version updates automatically to `dev` branch
 
 ## Version Bump Examples
 
@@ -184,18 +187,18 @@ fi
 
 ### Files Updated Automatically
 
-When a new version is calculated, these files are automatically updated:
+When a new version is calculated and pushing to `dev` branch, these files are automatically updated:
 
 1. **Helm Charts:**
    - `deploy/helm/metrics-api/values.yaml`
    - `deploy/helm/ui/values.yaml`
    - `deploy/helm/alerting/values.yaml`
+   - `deploy/helm/mcp-server/values.yaml`
 
 2. **Build Configuration:**
    - `Makefile` (VERSION variable)
 
-3. **Git Tags:**
-   - New version tag is created automatically
+**Note**: _Version file updates only occur when pushing to the `dev` branch. When pushing to `main` branch, container images are built with the calculated version but version files remain unchanged._
 
 ### Container Image Naming
 
@@ -243,7 +246,9 @@ git commit -m "docs: update API documentation for new endpoints"
 ### Common Issues
 
 1. **Wrong version bump**: Check commit message keywords
-2. **Version not updating**: Ensure PR is merged to `main` or `dev`
+2. **Version not updating**:
+   - For `dev` branch: Ensure PR is merged to `dev`
+   - For `main` branch: Version files are not auto-updated (uses existing versions)
 3. **Build failures**: Check container registry permissions
 4. **Git conflicts**: Resolve conflicts in version update commits
 

--- a/docs/SEMANTIC_VERSIONING.md
+++ b/docs/SEMANTIC_VERSIONING.md
@@ -34,18 +34,18 @@ The workflow determines version bumps in this **order of priority**:
 ## How It Works
 
 1. **Trigger**: When PRs are merged to `main` or `dev` branches, or manually via `workflow_dispatch`
-   - **Version file updates**: Only occur when pushing to `dev` branch
-   - **Container builds**: Occur for both `main` and `dev` branches
+   - **Version file updates**: Only occur when pushing to non-main branches
+   - **Container builds**: Occur for all branches
 2. **Version calculation**: Analyzes PR labels and PR title **first**, then falls back to commit messages to determine bump type
 3. **Version increment**: Increments from the current version in Makefile (or starts from `0.1.1` if no version exists)
 4. **Container images**: Builds and pushes images to `quay.io/ecosystem-appeng/{IMAGE_PREFIX}-{component}:{version}` (e.g., `quay.io/ecosystem-appeng/aiobs-metrics-api:1.2.3`)
-5. **Auto-update**: Updates version files **only when pushing to `dev` branch**:
+5. **Auto-update**: Updates version files **only when pushing to non-main branches**:
    - `deploy/helm/metrics-api/values.yaml`
    - `deploy/helm/ui/values.yaml` 
    - `deploy/helm/alerting/values.yaml`
    - `deploy/helm/mcp-server/values.yaml`
    - `Makefile` VERSION variable
-6. **Git commit**: Commits version updates automatically to `dev` branch
+6. **Git commit**: Commits version updates automatically to the current branch
 
 ## Version Bump Examples
 
@@ -187,7 +187,7 @@ fi
 
 ### Files Updated Automatically
 
-When a new version is calculated and pushing to `dev` branch, these files are automatically updated:
+When a new version is calculated and pushing to a non-main branch, these files are automatically updated:
 
 1. **Helm Charts:**
    - `deploy/helm/metrics-api/values.yaml`
@@ -198,7 +198,7 @@ When a new version is calculated and pushing to `dev` branch, these files are au
 2. **Build Configuration:**
    - `Makefile` (VERSION variable)
 
-**Note**: _Version file updates only occur when pushing to the `dev` branch. When pushing to `main` branch, container images are built with the calculated version but version files remain unchanged._
+**Note**: _Version file updates only occur when pushing to non-main branches. When pushing to `main` branch, container images are built with the calculated version but version files remain unchanged._
 
 ### Container Image Naming
 
@@ -247,7 +247,7 @@ git commit -m "docs: update API documentation for new endpoints"
 
 1. **Wrong version bump**: Check commit message keywords
 2. **Version not updating**:
-   - For `dev` branch: Ensure PR is merged to `dev`
+   - For non-main branches: Ensure PR is merged to the branch
    - For `main` branch: Version files are not auto-updated (uses existing versions)
 3. **Build failures**: Check container registry permissions
 4. **Git conflicts**: Resolve conflicts in version update commits


### PR DESCRIPTION
## Changes

Current GitHub Actions `build-and-push` workflow was failing due to repository rule violations when trying to update version files directly in the `main` branch, which has branch protection rules requiring all changes to go through pull requests.

To fix the above error, workflow has been modified to only update version files when pushing to the `dev` branch, while still building and pushing container images for both `main` and `dev` branches, respecting the branch protection rules.

After the changes, here's how the workflow will differ for `main` vs `dev` branches:

| Branch | Semantic Version | Build Images | Update Version Files | Push Changes |
|--------|-----------------|-------------|---------------------|--------------|
| `dev`  | ✅ Yes         | ✅ Yes      | ✅ Yes              | ✅ Yes       |
| `main` | ✅ Yes         | ✅ Yes      | ❌ No (skipped)     | ❌ No (skipped)        |


Screenshot showing `Update versions...` job being skipped in the main branch:
<img width="1191" height="489" alt="Screenshot 2025-09-04 at 11 24 17 AM" src="https://github.com/user-attachments/assets/495a2304-d883-4c6f-84ec-fc8b4e88e9f7" />

<img width="1626" height="525" alt="Screenshot 2025-09-04 at 11 26 33 AM" src="https://github.com/user-attachments/assets/e3074e57-85f3-426b-a138-aa93542e961a" />



## Checklist

- [ ] Verify on the cluster
- [ ] Update tests if applicable and run `pytest`
- [x] Add screenshots (if applicable)
- [ ] Update readme (if applicable)