### PR TITLE
fix the issue in deploy workflow run where the wrong branch was being…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_ref || github.ref }}
+          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Show branch and commit info
         run: |


### PR DESCRIPTION
## Changes

The change from `${{ github.event.workflow_run.head_ref || github.ref }}` to `${{ github.event.workflow_run.head_branch }}` will ensure that:

✅ The deploy workflow uses the correct branch (not main)
✅ PR deployments will use the PR branch code
✅ No fallback to main branch occurs

This fix addresses the exact issue shown in [this workflow run](https://github.com/rh-ai-quickstart/openshift-ai-observability-summarizer/actions/runs/17556762146) where the wrong branch (`main`) was being checked out for deployment instead of `dev` branch.

## Checklist

- [ ] Verify on the cluster
- [ ] Update tests if applicable and run `pytest`
- [ ] Add screenshots (if applicable)
- [ ] Update readme (if applicable)