### PR TITLE
using intermediate steps to get correct branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,8 +56,6 @@ jobs:
           echo "Event: ${{ github.event_name }}"
           echo "Repository: ${{ github.repository }}"
           echo "Actor: ${{ github.actor }}"
-          echo "Workflow run head branch: ${{ github.event.workflow_run.head_branch }}"
-          echo "Workflow run head sha: ${{ github.event.workflow_run.head_sha }}"
           echo "::endgroup::"
 
       - name: Install OpenShift CLI

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,19 +31,33 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
 
     steps:
+      - name: Determine target branch
+        id: target-branch
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "target_branch=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
+            echo "Using workflow_run head_branch: ${{ github.event.workflow_run.head_branch }}"
+          else
+            echo "target_branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            echo "Using current ref: ${{ github.ref_name }}"
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: ${{ steps.target-branch.outputs.target_branch }}
+          fetch-depth: 0
 
       - name: Show branch and commit info
         run: |
           echo "::group::Repository Information"
-          echo "Branch: ${{ github.ref_name }}"
-          echo "Commit SHA: ${{ github.sha }}"
+          echo "Target Branch: ${{ steps.target-branch.outputs.target_branch }}"
+          echo "Actual git branch: $(git branch --show-current)"
           echo "Event: ${{ github.event_name }}"
           echo "Repository: ${{ github.repository }}"
           echo "Actor: ${{ github.actor }}"
+          echo "Workflow run head branch: ${{ github.event.workflow_run.head_branch }}"
+          echo "Workflow run head sha: ${{ github.event.workflow_run.head_sha }}"
           echo "::endgroup::"
 
       - name: Install OpenShift CLI
@@ -64,4 +78,8 @@ jobs:
           NAMESPACE: ${{ env.NAMESPACE }}
         run: |
           # Run make target from root dir
+          echo "Deploying app from branch: `git branch --show-current`"
+          echo "Grepping version/tag from Makefile and values.yaml"
+          grep "^VERSION" Makefile
+          find deploy -name "values.yaml" -exec grep -H 'tag: ' {} \;
           make install


### PR DESCRIPTION
## Changes

- Enhanced branch determination logic - Added intermediate step to correctly identify the target branch for deployment
- Improved workflow_run handling - Now properly uses workflow_run.head_branch when triggered by workflow events
- Better fallback logic - Uses github.ref_name for manual workflow_dispatch triggers
- Enhanced debugging output - Added logging to show which branch is being used

Verified on my personal repo. Attaching screenshot from the `Deploy` workflow from there:

<img width="1128" height="850" alt="Screenshot 2025-09-09 at 4 40 14 PM" src="https://github.com/user-attachments/assets/b5e976cf-df10-4258-af4b-84e9398856e6" />


## Checklist

- [ ] Verify on the cluster
- [ ] Update tests if applicable and run `pytest`
- [ ] Add screenshots (if applicable)
- [ ] Update readme (if applicable)