### PR TITLE
 feat: [APPENG-3503] MCP Transition - OpenShift Metrics: ui change to call MCP chat_openshift

### DIFF
--- a/src/core/metrics.py
+++ b/src/core/metrics.py
@@ -864,11 +864,11 @@ def chat_openshift_metrics(
     )
     metric_dfs: Dict[str, Any] = {}
     for label, query in metrics_to_fetch.items():
-        try:
-            df = fetch_openshift_metrics(query, start_ts, end_ts, namespace_for_query)
-            metric_dfs[label] = df
-        except Exception:
-            metric_dfs[label] = pd.DataFrame()
+        # Allow Prometheus connectivity/request exceptions to propagate so callers
+        # (e.g., MCP tools) can surface structured PROMETHEUS_ERROR instead of
+        # falling back to a generic "no data" message.
+        df = fetch_openshift_metrics(query, start_ts, end_ts, namespace_for_query)
+        metric_dfs[label] = df
 
     # If no data at all, avoid LLM call and return helpful message
     has_any_data = any(isinstance(df, pd.DataFrame) and not df.empty for df in metric_dfs.values())

--- a/src/ui/mcp_client_helper.py
+++ b/src/ui/mcp_client_helper.py
@@ -787,6 +787,109 @@ def parse_model_config_text(text: str) -> Dict[str, Any]:
         return {}
 
 
+def chat_openshift_mcp(
+    metric_category: str,
+    question: str,
+    scope: str,
+    namespace: Optional[str],
+    start_ts: int,
+    end_ts: int,
+    summarize_model_id: str,
+    api_key: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Chat about OpenShift metrics via MCP chat_openshift tool."""
+    try:
+        # Soft health check: log but don't fail early; still attempt the tool call
+        try:
+            if not mcp_client.check_server_health():
+                logger.warning("MCP health check failed; proceeding to attempt chat_openshift anyway")
+        except Exception:
+            logger.warning("MCP health check error; proceeding anyway")
+
+        params = {
+            "metric_category": metric_category,
+            "question": question,
+            "scope": scope,
+            "namespace": namespace or "",
+            "start_datetime": epoch_to_iso(start_ts),
+            "end_datetime": epoch_to_iso(end_ts),
+            "summarize_model_id": summarize_model_id,
+        }
+        if api_key:
+            params["api_key"] = api_key
+
+        result = mcp_client.call_tool_sync("chat_openshift", params)
+        if result is None:
+            return {
+                "error": "MCP chat request timed out",
+                "error_type": "mcp_structured",
+                "error_details": {
+                    "is_error": True,
+                    "error_code": "TIMEOUT_ERROR",
+                    "message": "MCP chat_openshift timed out. The LLM service may be unavailable or slow.",
+                },
+            }
+        # If server returned a structured MCP error, surface it
+        # Prometheus or LLM structured errors from MCP
+        err = parse_mcp_error(result)
+        if err:
+            return {
+                "error": err.get("message", "MCP tool error"),
+                "error_type": "mcp_structured",
+                "error_details": err,
+            }
+        response_text = extract_text_from_mcp_result(result) or ""
+        
+        # Parse the JSON response
+        try:
+            return json.loads(response_text)
+        except json.JSONDecodeError:
+            # If MCP returned an error body encoded as list/dict text, surface as error
+            possible_err = parse_mcp_error(result)
+            if possible_err:
+                return {
+                    "error": possible_err.get("message", "MCP tool error"),
+                    "error_type": "mcp_structured",
+                    "error_details": possible_err,
+                }
+            logger.error(f"Failed to parse chat_openshift response as JSON: {response_text}")
+            return {"summary": response_text, "promql": ""}
+            
+    except requests.exceptions.ConnectionError as e:
+        logger.error(f"MCP connection error during chat_openshift: {e}")
+        return {
+            "error": "MCP server is not available",
+            "error_type": "mcp_structured",
+            "error_details": {
+                "is_error": True,
+                "error_code": "CONNECTION_ERROR",
+                "message": "MCP server is not available",
+            },
+        }
+    except requests.exceptions.Timeout as e:
+        logger.error(f"MCP timeout during chat_openshift: {e}")
+        return {
+            "error": "MCP chat request timed out",
+            "error_type": "mcp_structured",
+            "error_details": {
+                "is_error": True,
+                "error_code": "TIMEOUT_ERROR",
+                "message": "MCP chat_openshift timed out. The LLM service may be unavailable or slow.",
+            },
+        }
+    except Exception as e:
+        logger.error(f"Error chatting with OpenShift via MCP: {e}")
+        return {
+            "error": str(e),
+            "error_type": "mcp_structured",
+            "error_details": {
+                "is_error": True,
+                "error_code": "INTERNAL_ERROR",
+                "message": str(e),
+            },
+        }
+
+
 def get_vllm_metrics_mcp() -> Dict[str, str]:
     """Get available vLLM metrics from MCP server.
     


### PR DESCRIPTION
## Changes
Enhanced UI to call MCP tool directly for chat OpenShift and appropriate exception handling is added.

Deployed and tested in the cluster:
1) Normal chat OpenShift functionality
2) When vLLM is down
3) When Prometheus is down
4) When MCP server is down

## Checklist

- [X ] Verify on the cluster
- [ ] Update tests if applicable and run `pytest`
- [ ] Add screenshots (if applicable)
- [ ] Update readme (if applicable)