### PR TITLE
Fix issue that causes MCP server to crash in OpenShift for analyze OpenShift metrics

### DIFF
--- a/deploy/helm/mcp-server/templates/deployment.yaml
+++ b/deploy/helm/mcp-server/templates/deployment.yaml
@@ -70,9 +70,9 @@ spec:
                 - -f
                 - http://0.0.0.0:{{ .Values.env.MCP_PORT }}/health
             initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
+            periodSeconds: 60
+            timeoutSeconds: 30
+            failureThreshold: 6
           readinessProbe:
             exec:
               command:
@@ -80,9 +80,9 @@ spec:
                 - -f
                 - http://0.0.0.0:{{ .Values.env.MCP_PORT }}/health
             initialDelaySeconds: 10
-            periodSeconds: 5
-            timeoutSeconds: 3
-            failureThreshold: 3
+            periodSeconds: 20
+            timeoutSeconds: 20
+            failureThreshold: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
Fix the liveness and readiness probes that cause MCP server to crash during analyzing OpenShift metrics

## Changes

Updated the liveness and readiness probes.

Deployed in the cluster under namespace zhang.

## Checklist

- [X] Verify on the cluster
- [ ] Update tests if applicable and run `pytest`
- [ ] Add screenshots (if applicable)
- [ ] Update readme (if applicable)