### PR TITLE
Fix OpenTelemetry Collector telemetry configuration

### DIFF
--- a/deploy/helm/observability/otel-collector/values.yaml
+++ b/deploy/helm/observability/otel-collector/values.yaml
@@ -141,9 +141,6 @@ collector:
           exporters:
             - debug
             - otlphttp/dev
-      telemetry:
-        metrics:
-          address: 0.0.0.0:8888
 
 # Tempo configuration for exporters
 tempo:


### PR DESCRIPTION
I noticed `otel-collector-collector` crashing in `obsservability-hub` ns and upon investigation, I found the cluster got updated for OpenTelemetry operator. Here's full timeline:

📅 Cluster Upgrade Timeline
Based on the investigation, here's when the OpenTelemetry Collector was upgraded:

🕐 Upgrade Timeline:
1. September 12, 2025 at 01:47:50Z:
   * OpenTelemetry Collector was **initially deployed** in the cluster
   * This was when the observability infrastructure was first set up
2. September 30, 2025 at 09:00:32Z:
   * **OpenTelemetry Operator was upgraded** from version `0.127.0-2` to `0.135.0-1`
   * This is when the cluster was upgraded to the newer version
3. September 30, 2025 at 15:30:09Z (today):
   * **OpenTelemetry Collector started failing** with the configuration error
   * The new operator version (0.135.0) no longer supported the old `address` format

🔍 What Happened:
1. **Original Deployment**: The helm chart was created on August 8, 2025 with the old configuration format
2. **Cluster Upgrade**: On September 30, 2025 (today), the OpenTelemetry Operator was upgraded from 0.127.0 to 0.135.0
3. **Compatibility Issue**: The new operator version changed the supported configuration format, breaking the existing deployment
4. **Failure**: The collector started crashing with `CrashLoopBackOff` due to the deprecated address key

⏰ Timeline Summary:
* August 8, 2025: Helm chart created with old format
* September 12, 2025: Initial deployment (worked with old operator)
* September 30, 2025 at 09:00: Operator upgraded to 0.135.0
* September 30, 2025 at 15:30: Collector started failing
* September 30, 2025 at 15:35: Fixed and redeployed

The cluster was upgraded **today** (**September 30, 2025**) at around 9:00 AM, which is why the issue appeared today even though no-one made any changes! 🎯


## Changes

- Remove deprecated 'address' key from telemetry.metrics configuration
- OpenTelemetry Collector 0.135.0 no longer supports the old format
- This fixes the CrashLoopBackOff issue in observability-hub namespace

Resolves: OpenTelemetry Collector deployment failure after operator upgrade


## Checklist

- [ ] Verify on the cluster
- [ ] Update tests if applicable and run `pytest`
- [ ] Add screenshots (if applicable)
- [ ] Update readme (if applicable)