### PR TITLE
feat: migrated chat_vllm from metrics-api to mcp-server

### DIFF
--- a/src/mcp_server/observability_mcp.py
+++ b/src/mcp_server/observability_mcp.py
@@ -27,6 +27,7 @@ class ObservabilityMCPServer:
             list_summarization_models,
             get_gpu_info,
             get_deployment_info,
+            chat_vllm,
         )
         from .tools.observability_openshift_tools import (
             analyze_openshift,
@@ -56,6 +57,7 @@ class ObservabilityMCPServer:
         self.mcp.tool()(list_summarization_models)
         self.mcp.tool()(get_gpu_info)
         self.mcp.tool()(get_deployment_info)
+        self.mcp.tool()(chat_vllm)
         
         # Register OpenShift tools
         self.mcp.tool()(analyze_openshift)

--- a/src/ui/ui.py
+++ b/src/ui/ui.py
@@ -30,6 +30,7 @@ from mcp_client_helper import (
     get_multi_models_mcp,
     get_gpu_info_mcp,
     get_deployment_info_mcp,
+    chat_vllm_mcp,
 )
 # Add current directory to Python path for consistent imports
 import sys
@@ -1111,21 +1112,21 @@ if page == "vLLM Metric Summarizer":
             if st.button("Ask"):
                 with st.spinner("Assistant is thinking..."):
                     try:
-                        reply = requests.post(
-                            f"{API_URL}/chat",
-                            json={
-                                "model_name": st.session_state["model_name"],
-                                "summarize_model_id": multi_model_name,
-                                "prompt_summary": st.session_state["prompt"],
-                                "question": question,
-                                "api_key": api_key,
-                            },
+                        # Use MCP tool instead of REST API
+                        result = chat_vllm_mcp(
+                            model_name=st.session_state["model_name"],
+                            prompt_summary=st.session_state["prompt"],
+                            question=question,
+                            summarize_model_id=multi_model_name,
+                            api_key=api_key,
                         )
-                        reply.raise_for_status()
-                        st.markdown("**Assistant's Response:**")
-                        st.markdown(reply.json()["response"])
-                    except requests.exceptions.HTTPError as http_err:
-                        handle_http_error(http_err.response, "Chat failed")
+                        
+                        # Handle errors
+                        if "error" in result:
+                            st.error(f"❌ Chat failed: {result['error']}")
+                        else:
+                            st.markdown("**Assistant's Response:**")
+                            st.markdown(result.get("response", "No response received"))
                     except Exception as e:
                         st.error(f"❌ Chat failed: {e}")
 

--- a/tests/ui/test_mcp_client_helper.py
+++ b/tests/ui/test_mcp_client_helper.py
@@ -436,3 +436,266 @@ Metrics Preview:
         
         assert isinstance(result, dict)
         assert len(result) == 0
+
+
+    # === CHAT_VLLM_MCP INTEGRATION TESTS ===
+
+    @patch.object(mcp_helper.mcp_client, 'check_server_health', return_value=True)
+    @patch.object(mcp_helper.mcp_client, 'call_tool_sync')
+    def test_chat_vllm_mcp_success(self, mock_call_tool, mock_health_check):
+        """Test successful vLLM chat via MCP"""
+        mock_call_tool.return_value = [{
+            "type": "text",
+            "text": "Based on the metrics provided, the average latency is approximately 2.5 seconds, which is within acceptable range for this model configuration."
+        }]
+        
+        result = mcp_helper.chat_vllm_mcp(
+            model_name="dev | llama-3.2-3b-instruct",
+            prompt_summary="GPU usage is at 85%, latency is 2.5s, throughput is 50 tokens/s",
+            question="What is the average latency?",
+            summarize_model_id="meta-llama/Llama-3.2-3B-Instruct",
+            api_key="test-api-key"
+        )
+        
+        # Verify the MCP tool was called with correct parameters
+        mock_call_tool.assert_called_once_with("chat_vllm", {
+            "model_name": "dev | llama-3.2-3b-instruct",
+            "prompt_summary": "GPU usage is at 85%, latency is 2.5s, throughput is 50 tokens/s",
+            "question": "What is the average latency?",
+            "summarize_model_id": "meta-llama/Llama-3.2-3B-Instruct",
+            "api_key": "test-api-key"
+        })
+        
+        # Verify response format
+        assert isinstance(result, dict)
+        assert "response" in result
+        assert "average latency is approximately 2.5 seconds" in result["response"]
+
+
+    @patch.object(mcp_helper.mcp_client, 'check_server_health', return_value=True)
+    @patch.object(mcp_helper.mcp_client, 'call_tool_sync')
+    def test_chat_vllm_mcp_without_api_key(self, mock_call_tool, mock_health_check):
+        """Test vLLM chat via MCP without API key (internal model)"""
+        mock_call_tool.return_value = [{
+            "type": "text",
+            "text": "The throughput of 50 tokens/s is good for this model size."
+        }]
+        
+        result = mcp_helper.chat_vllm_mcp(
+            model_name="test-model",
+            prompt_summary="GPU usage is at 85%, throughput is 50 tokens/s",
+            question="How is the throughput?",
+            summarize_model_id="internal-model"
+        )
+        
+        # Verify API key is not included when not provided
+        call_args = mock_call_tool.call_args[0][1]
+        assert "api_key" not in call_args
+        
+        assert "response" in result
+        assert "throughput of 50 tokens/s" in result["response"]
+
+
+    @patch.object(mcp_helper.mcp_client, 'check_server_health', return_value=True)
+    @patch.object(mcp_helper.mcp_client, 'call_tool_sync')
+    def test_chat_vllm_mcp_with_markdown_response(self, mock_call_tool, mock_health_check):
+        """Test vLLM chat with markdown-formatted response"""
+        mock_call_tool.return_value = [{
+            "type": "text",
+            "text": "## Performance Analysis\n\n**GPU Usage:** 85%\n- This is within normal range\n- Consider optimization if sustained\n\n**Recommendations:**\n1. Monitor GPU temperature\n2. Check memory usage patterns"
+        }]
+        
+        result = mcp_helper.chat_vllm_mcp(
+            model_name="test-model",
+            prompt_summary="Test metrics summary",
+            question="Analyze the performance",
+            summarize_model_id="test-summarizer"
+        )
+        
+        assert "response" in result
+        assert "## Performance Analysis" in result["response"]
+        assert "**GPU Usage:** 85%" in result["response"]
+        assert "**Recommendations:**" in result["response"]
+
+
+    @patch.object(mcp_helper.mcp_client, 'check_server_health', return_value=False)
+    def test_chat_vllm_mcp_server_down(self, mock_health_check):
+        """Test chat_vllm_mcp when MCP server is down"""
+        result = mcp_helper.chat_vllm_mcp(
+            model_name="test-model",
+            prompt_summary="Test summary",
+            question="Test question?",
+            summarize_model_id="test-model"
+        )
+        
+        # Should return error when server is down
+        assert isinstance(result, dict)
+        assert "error" in result
+        assert result["error"] == "MCP server is not available"
+        assert result["error_type"] == "mcp_structured"
+
+
+    @patch.object(mcp_helper.mcp_client, 'check_server_health', return_value=True)
+    @patch.object(mcp_helper.mcp_client, 'call_tool_sync')
+    def test_chat_vllm_mcp_validation_error(self, mock_call_tool, mock_health_check):
+        """Test chat_vllm_mcp with validation error from MCP server"""
+        # Simulate MCP structured error response
+        mock_call_tool.return_value = [{
+            "type": "text",
+            "text": """❌ **Error (INVALID_INPUT)**
+
+**Message:** Required parameter missing: question
+
+**Field:** question
+
+**How to fix:** 
+Provide a valid question parameter for the chat request."""
+        }]
+        
+        result = mcp_helper.chat_vllm_mcp(
+            model_name="test-model",
+            prompt_summary="Test summary",
+            question="",  # Empty question should trigger validation error
+            summarize_model_id="test-model"
+        )
+        
+        # Should detect the MCP structured error
+        assert isinstance(result, dict)
+        assert "error" in result
+        assert result["error_type"] == "mcp_structured"
+
+
+    @patch.object(mcp_helper.mcp_client, 'check_server_health', return_value=True)
+    @patch.object(mcp_helper.mcp_client, 'call_tool_sync')
+    def test_chat_vllm_mcp_llm_service_error(self, mock_call_tool, mock_health_check):
+        """Test chat_vllm_mcp when LLM service fails"""
+        # Simulate LLM service error from MCP server
+        mock_call_tool.return_value = [{
+            "type": "text",
+            "text": """❌ **Error (LLM_SERVICE_ERROR)**
+
+**Message:** Failed to generate chat response: LLM service unavailable
+
+**How to fix:** 
+Please check your API key or try again later."""
+        }]
+        
+        result = mcp_helper.chat_vllm_mcp(
+            model_name="test-model",
+            prompt_summary="Test summary",
+            question="Test question?",
+            summarize_model_id="test-model",
+            api_key="invalid-key"
+        )
+        
+        # Should detect the MCP structured error
+        assert isinstance(result, dict)
+        assert "error" in result
+        assert result["error_type"] == "mcp_structured"
+
+
+    @patch.object(mcp_helper.mcp_client, 'check_server_health', return_value=True)
+    @patch.object(mcp_helper.mcp_client, 'call_tool_sync')
+    def test_chat_vllm_mcp_no_response(self, mock_call_tool, mock_health_check):
+        """Test chat_vllm_mcp when MCP returns empty response"""
+        mock_call_tool.return_value = []
+        
+        result = mcp_helper.chat_vllm_mcp(
+            model_name="test-model",
+            prompt_summary="Test summary",
+            question="Test question?",
+            summarize_model_id="test-model"
+        )
+        
+        # Should handle empty response gracefully
+        assert isinstance(result, dict)
+        assert "error" in result
+        assert "No response from MCP chat_vllm tool" in result["error"]
+
+
+    @patch.object(mcp_helper.mcp_client, 'check_server_health', return_value=True)
+    @patch.object(mcp_helper.mcp_client, 'call_tool_sync')
+    def test_chat_vllm_mcp_complex_question(self, mock_call_tool, mock_health_check):
+        """Test chat_vllm_mcp with complex multi-part question"""
+        mock_call_tool.return_value = [{
+            "type": "text",
+            "text": """Based on the metrics analysis:
+
+1. **GPU Performance**: The GPU is running at 85% utilization with temperature at 72°C, which is within safe operating range.
+
+2. **Latency Analysis**: 
+   - P50 latency: 1.2s
+   - P95 latency: 2.5s
+   - P99 latency: 3.1s
+
+3. **Recommendations**:
+   - Current configuration is optimal for this workload
+   - Consider batch size tuning if P99 latency increases
+   - Monitor GPU temperature trends over longer periods"""
+        }]
+        
+        result = mcp_helper.chat_vllm_mcp(
+            model_name="prod | llama-3-70b",
+            prompt_summary="GPU: 85%, Temp: 72°C, P50: 1.2s, P95: 2.5s, P99: 3.1s",
+            question="Can you provide a comprehensive analysis of GPU performance, latency distribution, and optimization recommendations?",
+            summarize_model_id="meta-llama/Llama-3.2-3B-Instruct",
+            api_key="test-key"
+        )
+        
+        assert "response" in result
+        assert "GPU Performance" in result["response"]
+        assert "Latency Analysis" in result["response"]
+        assert "Recommendations" in result["response"]
+        assert "P50 latency" in result["response"]
+        assert "P95 latency" in result["response"]
+
+
+    @patch.object(mcp_helper.mcp_client, 'check_server_health', return_value=True)
+    @patch.object(mcp_helper.mcp_client, 'call_tool_sync')
+    def test_chat_vllm_mcp_exception_handling(self, mock_call_tool, mock_health_check):
+        """Test chat_vllm_mcp exception handling"""
+        mock_call_tool.side_effect = Exception("Network timeout")
+        
+        result = mcp_helper.chat_vllm_mcp(
+            model_name="test-model",
+            prompt_summary="Test summary",
+            question="Test question?",
+            summarize_model_id="test-model"
+        )
+        
+        # Should handle exceptions gracefully
+        assert isinstance(result, dict)
+        assert "error" in result
+        assert "Network timeout" in result["error"]
+        assert result["error_type"] == "mcp_structured"
+
+
+    @patch.object(mcp_helper.mcp_client, 'check_server_health', return_value=True)
+    @patch.object(mcp_helper.mcp_client, 'call_tool_sync')
+    def test_chat_vllm_mcp_double_encoded_json_response(self, mock_call_tool, mock_health_check):
+        """Test chat_vllm_mcp with double-encoded JSON response (bug fix)"""
+        # Simulate case where response_text is a JSON string representation
+        # This was causing the UI to show: [{"type":"text","text":"..."}]
+        json_string_response = '[{"type":"text","text":"The current GPU temperature is 39.3°C. This is within normal range."}]'
+        
+        # Mock call_tool_sync to return a response where extract_text_from_mcp_result 
+        # returns the JSON string instead of the actual text
+        mock_call_tool.return_value = [{
+            "type": "text",
+            "text": json_string_response  # This is the double-encoded case
+        }]
+        
+        result = mcp_helper.chat_vllm_mcp(
+            model_name="test-model",
+            prompt_summary="GPU metrics summary",
+            question="What is the GPU Temperature?",
+            summarize_model_id="test-model"
+        )
+        
+        # Should properly extract the text from the double-encoded response
+        assert isinstance(result, dict)
+        assert "response" in result
+        assert "The current GPU temperature is 39.3°C" in result["response"]
+        # Should NOT contain the JSON structure markers
+        assert '[{"type"' not in result["response"]
+        assert '"text"' not in result["response"]


### PR DESCRIPTION
## Changes

Completes the migration of vLLM chat functionality from direct REST API calls to MCP  tools, This will make the UI fully MCP-based 

<img width="787" height="418" alt="Screenshot 2025-10-01 at 1 51 04 PM" src="https://github.com/user-attachments/assets/5723ec55-96f9-47e2-b2e3-09265a3c2a47" />

## Checklist

- [ ] Verify on the cluster
- [ ] Update tests if applicable and run `pytest`
- [ ] Add screenshots (if applicable)
- [ ] Update readme (if applicable)