### PR TITLE
Fixed model_config generation for both Makefile and local-dev.sh

### DIFF
--- a/docs/DEV_GUIDE.md
+++ b/docs/DEV_GUIDE.md
@@ -74,27 +74,37 @@ export DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib:$DYLD_FALLBACK_LIBRARY_PATH
 
 ### Local Development
 ```bash
-# Set up port-forwarding to cluster services
+# Set up port-forwarding to cluster services (default LLM: llama-3.2-3b-instruct)
 ./scripts/local-dev.sh -n <DEFAULT_NAMESPACE>
+
+# With specific LLM model (optional)
+./scripts/local-dev.sh -n <DEFAULT_NAMESPACE> -l llama-3.1-8b-instruct
 
 # If model is in different namespace:
 ./scripts/local-dev.sh -n <DEFAULT_NAMESPACE> -m <MODEL_NAMESPACE>
 
+# Use cluster config instead of generating new one:
+./scripts/local-dev.sh -n <DEFAULT_NAMESPACE> -c cluster
+
 # This script sets up:
 # - Virtual environment activation (.venv)
+# - MODEL_CONFIG generation (merges base models + specified LLM)
 # - Port-forwarding to Llamastack (localhost:8321)
 # - Port-forwarding to Model service (localhost:8080)
 # - Port-forwarding to Thanos (localhost:9090)
-# - Metrics API (localhost:8000)
+# - MCP Server (localhost:8085)
 # - Streamlit UI (localhost:8501)
 
-# Example:
-./scripts/local-dev.sh -n default-ns
-./scripts/local-dev.sh -n default-ns -m model-ns  # Model in different namespace
+# Examples:
+./scripts/local-dev.sh -n default-ns                      # Default LLM
+./scripts/local-dev.sh -n default-ns -l llama-3.1-8b-instruct  # Custom LLM
+./scripts/local-dev.sh -n default-ns -m model-ns          # Model in different namespace
+./scripts/local-dev.sh -n default-ns -c cluster           # Use cluster config
 ```
 
 **Note**: The script automatically:
 - Activates Python virtual environment if `.venv` exists
+- Generates MODEL_CONFIG by merging base external models (OpenAI, Google, Anthropic) with your specified LLM
 - Uses service-based port forwarding for better reliability
 - Supports separate namespaces for different services
 
@@ -297,6 +307,95 @@ Common models include:
 - `llama-3-1-8b-instruct`
 - `llama-3-3-70b-instruct`
 - `llama-guard-3-8b` (safety model)
+
+### Model Configuration Generation
+
+**Location**: `scripts/generate-model-config.sh`
+
+**Purpose**: Single source of truth for dynamically generating model configurations. Used by both Makefile (OpenShift deployment) and local-dev.sh (local development).
+
+**Architecture**:
+```
+generate-model-config.sh
+├── Used by Makefile (with --helm-format flag)
+│   └── Generates: JSON + Helm YAML values file
+└── Used by local-dev.sh (without flag)
+    └── Generates: JSON only
+```
+
+**How it works**:
+1. **Template Substitution**: Reads `deploy/helm/default-model.json.template` and substitutes:
+   - `$MODEL_ID` → Full model path (e.g., `meta-llama/Llama-3.2-3B-Instruct`)
+   - `$MODEL_NAME` → Service name (e.g., `llama-3-2-3b-instruct`)
+
+2. **JSON Merging**: Merges the LLM-specific config with base external models from `deploy/helm/model-config.json`:
+   ```bash
+   jq -s '.[0] * .[1]' new_model_config.json model-config.json > final_config.json
+   ```
+
+3. **Export**: Sets `MODEL_CONFIG` environment variable for use by services
+
+**Parameters**:
+- **LLM model name** (optional): Model identifier (default: `llama-3-2-3b-instruct`)
+- **`--helm-format` flag** (optional): Generate Helm values YAML file in addition to JSON
+
+**Output Files** (in `/tmp`):
+- `gen_model_config-list_models_output.txt` - Available models from Helm chart
+- `gen_model_config-final_config.json` - Merged JSON configuration
+- `gen_model_config-for_helm.yaml` - Helm values format (only with `--helm-format`)
+
+**Usage Examples**:
+```bash
+# Direct usage (for debugging/testing)
+source scripts/generate-model-config.sh
+generate_model_config                                    # Use default model
+generate_model_config "llama-3.1-8b-instruct"           # Specific model, JSON only
+generate_model_config "llama-3.2-3b-instruct" --helm-format  # JSON + Helm YAML
+
+# Automatic usage via Makefile
+make install NAMESPACE=your-ns LLM=llama-3.1-8b-instruct
+# → Calls: generate_model_config "llama-3.1-8b-instruct" --helm-format
+
+# Automatic usage via local-dev.sh
+./scripts/local-dev.sh -n your-ns -l llama-3.1-8b-instruct
+# → Calls: generate_model_config "llama-3.1-8b-instruct" (no --helm-format)
+```
+
+**Example: Config Merging Process**:
+```bash
+# 1. Template (default-model.json.template)
+{
+  "$MODEL_ID": {
+    "external": false,
+    "requiresApiKey": false,
+    "serviceName": "$MODEL_NAME"
+  }
+}
+
+# 2. After substitution (new_model_config.json)
+{
+  "meta-llama/Llama-3.2-3B-Instruct": {
+    "external": false,
+    "requiresApiKey": false,
+    "serviceName": "llama-3-2-3b-instruct"
+  }
+}
+
+# 3. Base config (model-config.json)
+{
+  "openai/gpt-4o-mini": { ... },
+  "google/gemini-2.5-flash": { ... },
+  "anthropic/claude-sonnet-4-20250514": { ... }
+}
+
+# 4. Final merged config (final_config.json)
+{
+  "meta-llama/Llama-3.2-3B-Instruct": { ... },  # ← LLM-specific
+  "openai/gpt-4o-mini": { ... },                 # ← Base external models
+  "google/gemini-2.5-flash": { ... },
+  "anthropic/claude-sonnet-4-20250514": { ... }
+}
+```
 
 ## 🔍 Common Development Patterns
 

--- a/scripts/generate-model-config.sh
+++ b/scripts/generate-model-config.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+# AI Observability Metric Summarizer - Local Development Script
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+
+check_tool_exists() {
+  local tool="$1"
+  if ! command -v "$tool" &> /dev/null; then
+    echo -e "${RED}❌ $tool is required but not installed${NC}"
+    exit 1
+  fi
+}
+
+# Get the default LLM model name
+get_default_model() {
+  echo "llama-3-2-3b-instruct"
+}
+
+# This function generates MODEL_CONFIG by merging LLM-specific config with base config
+# Similar to Makefile's generate-model-config target
+# Usage: generate_model_config "meta-llama/llama-3.2-3b-instruct" [--helm-format]
+generate_model_config() {
+  local DEFAULT_MODEL=$(get_default_model)
+  local LLM="${1:-$DEFAULT_MODEL}"
+  local CREATE_HELM_FILE=false
+  local GEN_MODEL_CONFIG_PREFIX="/tmp/gen_model_config"
+  local RAG_CHART="rag"
+
+  # Check for --helm-format flag
+  if [ "$2" = "--helm-format" ]; then
+    CREATE_HELM_FILE=true
+  fi
+
+  echo -e "${BLUE}🔧 Generating MODEL_CONFIG...${NC}"
+  echo -e "${BLUE}   LLM: $LLM${NC}"
+  if [ "$CREATE_HELM_FILE" = true ]; then
+    echo -e "${BLUE}   Helm format: enabled${NC}"
+  fi
+
+  # Check if jq is available
+  check_tool_exists "jq"
+
+  # Check if helm is available
+  check_tool_exists "helm"
+
+  echo -e "${BLUE}   → Running list-models to find available models...${NC}"
+  # Run helm template to get available models
+  cd deploy/helm && helm template dummy-release "$RAG_CHART" --set llm-service._debugListModels=true 2>/dev/null | grep "^model:" > "${GEN_MODEL_CONFIG_PREFIX}-list_models_output.txt"
+  cd - > /dev/null
+
+  if [ ! -s "${GEN_MODEL_CONFIG_PREFIX}-list_models_output.txt" ]; then
+      echo -e "${RED}❌ Failed to get list of available models${NC}"
+      return 1
+  fi
+
+  echo -e "${BLUE}     → list-models output saved to ${GEN_MODEL_CONFIG_PREFIX}-list_models_output.txt${NC}"
+
+  # Find the model line matching the LLM
+  echo -e "${BLUE}     → Searching for model: $LLM${NC}"
+  MODEL_LINE=$(grep "model: $LLM (" "${GEN_MODEL_CONFIG_PREFIX}-list_models_output.txt" || echo "")
+
+  if [ -z "$MODEL_LINE" ]; then
+      echo -e "${RED}❌ Error: Model '$LLM' not found in available models${NC}"
+      echo -e "${YELLOW}→ Available models:${NC}"
+      cat "${GEN_MODEL_CONFIG_PREFIX}-list_models_output.txt"
+      return 1
+  fi
+
+  echo -e "${BLUE}     → Found MODEL_LINE: $MODEL_LINE${NC}"
+
+  # Extract MODEL_NAME and MODEL_ID
+  echo -e "${BLUE}   → Extracting MODEL_NAME and MODEL_ID from MODEL_LINE${NC}"
+  MODEL_NAME=$(echo "$MODEL_LINE" | sed 's/model: \([^(]*\)(.*)/\1/' | tr -d '[:space:]')
+  MODEL_ID=$(echo "$MODEL_LINE" | sed 's/model: [^(]*(\([^)]*\))/\1/' | tr -d '[:space:]')
+
+  echo -e "${BLUE}     → Extracted MODEL_NAME: $MODEL_NAME, MODEL_ID: $MODEL_ID${NC}"
+
+  # Generate new model config from template
+  echo -e "${BLUE}   → Generating JSON configuration from template...${NC}"
+  if [ ! -f "deploy/helm/default-model.json.template" ]; then
+      echo -e "${RED}❌ Template file not found: deploy/helm/default-model.json.template${NC}"
+      return 1
+  fi
+
+  sed "s|\$MODEL_ID|$MODEL_ID|g; s|\$MODEL_NAME|$MODEL_NAME|g" deploy/helm/default-model.json.template > "${GEN_MODEL_CONFIG_PREFIX}-new_model_config.json"
+
+  # Merge with base model config
+  echo -e "${BLUE}     → Merging with existing model-config.json...${NC}"
+  if [ ! -f "deploy/helm/model-config.json" ]; then
+      echo -e "${RED}❌ Base config file not found: deploy/helm/model-config.json${NC}"
+      return 1
+  fi
+
+  jq -s '.[0] * .[1]' "${GEN_MODEL_CONFIG_PREFIX}-new_model_config.json" deploy/helm/model-config.json > "${GEN_MODEL_CONFIG_PREFIX}-final_config.json"
+
+  if [ $? -ne 0 ]; then
+      echo -e "${RED}❌ Failed to merge configurations${NC}"
+      return 1
+  fi
+
+  # Load the final config into MODEL_CONFIG
+  export MODEL_CONFIG=$(cat "${GEN_MODEL_CONFIG_PREFIX}-final_config.json")
+
+  if [ -z "$MODEL_CONFIG" ]; then
+      echo -e "${RED}❌ Failed to load final configuration${NC}"
+      return 1
+  fi
+
+  echo -e "${GREEN}  ✅ MODEL_CONFIG generated successfully${NC}"
+  echo -e "${GREEN}     Final merged configuration saved in ${GEN_MODEL_CONFIG_PREFIX}-final_config.json${NC}"
+  echo -e "${BLUE}     → Available models: $(echo "$MODEL_CONFIG" | jq -r 'keys | join(", ")')${NC}"
+
+  # Generate Helm-formatted YAML file only if requested (for Makefile usage)
+  if [ "$CREATE_HELM_FILE" = true ]; then
+    echo -e "${BLUE}  → Creating Helm values file...${NC}"
+    (echo "modelConfig:"; cat "${GEN_MODEL_CONFIG_PREFIX}-final_config.json" | sed 's/^/  /') > "${GEN_MODEL_CONFIG_PREFIX}-for_helm.yaml"
+    echo -e "${GREEN}   Helm values file created: ${GEN_MODEL_CONFIG_PREFIX}-for_helm.yaml${NC}"
+  fi
+
+  # Cleanup intermediate file
+  rm -f "${GEN_MODEL_CONFIG_PREFIX}-new_model_config.json"
+
+  return 0
+}

--- a/scripts/generate-model-config.sh
+++ b/scripts/generate-model-config.sh
@@ -24,8 +24,8 @@ get_default_model() {
 }
 
 # This function generates MODEL_CONFIG by merging LLM-specific config with base config
-# Similar to Makefile's generate-model-config target
-# Usage: generate_model_config "meta-llama/llama-3.2-3b-instruct" [--helm-format]
+# Used by both Makefile's generate-model-config target and local-dev.sh
+# Usage: generate_model_config "llama-3.1-8b-instruct" [--helm-format]
 generate_model_config() {
   local DEFAULT_MODEL=$(get_default_model)
   local LLM="${1:-$DEFAULT_MODEL}"

--- a/scripts/local-dev.sh
+++ b/scripts/local-dev.sh
@@ -157,7 +157,7 @@ create_port_forward() {
 
     # Check if resource name is found
     if [ -z "$resource_name" ]; then
-        echo -e "${YELLOW}⚠️  $description service NOT found in $namespace namespace. Exiting...${NC}"
+        echo -e "${YELLOW}⚠️  $description resource NOT found in $namespace namespace. Exiting...${NC}"
         exit 1
     fi
     
@@ -178,7 +178,7 @@ start_port_forwards() {
     create_port_forward "$LLAMASTACK_SERVICE" "$LLAMASTACK_PORT" "8321" "$DEFAULT_NAMESPACE" "LlamaStack" "🦙"
     
     # Find Llama Model service
-    LLAMA_MODEL_SERVICE=$(oc get services -n "$LLAMA_MODEL_NAMESPACE" -o name -l 'app=isvc.llama-3-2-3b-instruct-predictor')
+    LLAMA_MODEL_SERVICE=$(oc get services -n "$LLAMA_MODEL_NAMESPACE" -o name -l "serving.kserve.io/inferenceservice=$LLM_MODEL, component=predictor")
     create_port_forward "$LLAMA_MODEL_SERVICE" "$LLAMA_MODEL_PORT" "8080" "$LLAMA_MODEL_NAMESPACE" "Llama Model" "🤖"
     
     # Find Tempo gateway service

--- a/scripts/local-dev.sh
+++ b/scripts/local-dev.sh
@@ -30,13 +30,15 @@ usage() {
     echo "  -n/-N NAMESPACE              Default namespace for pods (required)"
     echo "  -m/-M NAMESPACE              Llama Model namespace (optional, use if model is in different namespace)"
     echo "  -c/-C CONFIG                 Model config source: 'local' or 'cluster' (default: local)"
+    echo "  -l/-L LLM_MODEL              LLM model to generate config for (default: llama-3.2-3b-instruct, only used with -c local)"
     echo ""
     echo "Examples:"
-    echo "  $0 -n default-ns                       # All pods/services in same namespace, use local config"
-    echo "  $0 -N default-ns                       # All pods/services in same namespace (uppercase), use local config"
-    echo "  $0 -n default-ns -m model-ns           # Model in different namespace than other pods/services, use local config"
+    echo "  $0 -n default-ns                       # Use local config with default LLM (llama-3.2-3b-instruct)"
+    echo "  $0 -N default-ns                       # Same as above (uppercase option)"
+    echo "  $0 -n default-ns -m model-ns           # Model in different namespace, use default LLM"
     echo "  $0 -n default-ns -c cluster            # Use cluster model config instead of local"
-    echo "  $0 -n default-ns -C local              # Explicitly use local model config (default)"
+    echo "  $0 -n default-ns -l llama-3.2-1b-instruct  # Generate config for llama-3.2-1b-instruct"
+    echo "  $0 -n default-ns -l llama-3.1-8b-instruct  # Generate config for llama-3.1-8b-instruct"
 }
 
 # Function to parse command line arguments
@@ -50,15 +52,18 @@ parse_args() {
     DEFAULT_NAMESPACE=""
     LLAMA_MODEL_NAMESPACE=""
     MODEL_CONFIG_SOURCE="local"  # Default to local
+    LLM_MODEL=""  # Optional LLM model for config generation
 
     # Parse standard arguments using getopts
-    while getopts "n:N:m:M:c:C:" opt; do
+    while getopts "n:N:m:M:c:C:l:L:" opt; do
         case $opt in
             n|N) DEFAULT_NAMESPACE="$OPTARG"
                  ;;
             m|M) LLAMA_MODEL_NAMESPACE="$OPTARG"
                  ;;
             c|C) MODEL_CONFIG_SOURCE="$OPTARG"
+                 ;;
+            l|L) LLM_MODEL="$OPTARG"
                  ;;
             *) echo -e "${RED}❌ INVALID option: [$OPTARG]${NC}"
                usage
@@ -215,34 +220,20 @@ ensure_port_free() {
     fi
 }
 
-# This function sets "MODEL_CONFIG" environment variable from local file
+# This function sets "MODEL_CONFIG" environment variable from cluster deployment or dynamically generated config
 set_model_config() {
-    echo -e "${BLUE}🔧 Setting up MODEL_CONFIG...${NC}"
-    echo -e "${BLUE}   Using config source: $MODEL_CONFIG_SOURCE${NC}"
-
     if [ "$MODEL_CONFIG_SOURCE" = "local" ]; then
-        # Use local model config
-        LOCAL_MODEL_CONFIG="deploy/helm/model-config.json"
-        if [ -f "$LOCAL_MODEL_CONFIG" ]; then
-            echo -e "${YELLOW}📋 Using LOCAL model config from: $LOCAL_MODEL_CONFIG${NC}"
-            echo -e "${YELLOW}   This includes additional models like Anthropic Claude for testing.${NC}"
-            export MODEL_CONFIG=$(cat "$LOCAL_MODEL_CONFIG")
-            if [ -n "$MODEL_CONFIG" ]; then
-                echo -e "${GREEN}✅ LOCAL MODEL_CONFIG loaded successfully${NC}"
-                echo -e "${BLUE}   Available models: $(echo "$MODEL_CONFIG" | jq -r 'keys | join(", ")')${NC}"
-                return 0
-            else
-                echo -e "${RED}❌ Failed to read local model config file${NC}"
-                exit 1
-            fi
+        # Generate model config dynamically (LLM_MODEL is optional, will use default if not specified)
+        # Script is already sourced in main(), just call the function
+        if generate_model_config "$LLM_MODEL"; then
+            return 0
         else
-            echo -e "${RED}❌ Local model config file not found: $LOCAL_MODEL_CONFIG${NC}"
-            echo -e "${YELLOW}   Please ensure the file exists or use cluster config with -c cluster${NC}"
+            echo -e "${RED}❌ Failed to generate MODEL_CONFIG${NC}"
             exit 1
         fi
     else
         # Use cluster config
-        echo -e "${BLUE}🔧 Using CLUSTER model config...${NC}"
+        echo -e "${BLUE}🔧 Setting up MODEL_CONFIG from cluster...${NC}"
         local MCP_SERVER_APP="mcp-server-app"
         MCP_SERVER_APP_DEPLOYMENT=$(oc get deploy $MCP_SERVER_APP -n "$DEFAULT_NAMESPACE" 2>/dev/null)
         if [ -n "$MCP_SERVER_APP_DEPLOYMENT" ]; then
@@ -289,23 +280,6 @@ start_local_services() {
     export DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib:$DYLD_FALLBACK_LIBRARY_PATH"
 
     set_model_config
-    
-    # Start Metrics API backend
-    echo -e "${BLUE}🔧 Starting Metrics API backend...${NC}"
-    ensure_port_free "$METRICS_API_PORT"
-    (cd src/api && PYTHON_LOG_LEVEL="$PYTHON_LOG_LEVEL" python3 -m uvicorn metrics_api:app --host 0.0.0.0 --port $METRICS_API_PORT --reload > /tmp/summarizer-metrics-api.log 2>&1) &
-    MCP_PID=$!
-    
-    # Wait for Metrics API to start
-    sleep 3
-    
-    # Test Metrics API service
-    if curl -s --connect-timeout 5 "http://localhost:$METRICS_API_PORT/models" > /dev/null; then
-        echo -e "${GREEN}✅ Metrics API backend started successfully${NC}"
-    else
-        echo -e "${RED}❌ Metrics API backend failed to start${NC}"
-        exit 1
-    fi
 
     # Start MCP server (HTTP transport)
     echo -e "${BLUE}🧩 Starting MCP Server (HTTP)...${NC}"
@@ -362,6 +336,9 @@ main() {
     parse_args "$@"
     check_prerequisites
 
+    # Source the shared script once (for model config generation and default model)
+    source scripts/generate-model-config.sh
+
     # Set cleanup trap only after successful prerequisite checks
     trap cleanup EXIT INT TERM
 
@@ -371,6 +348,13 @@ main() {
     echo -e "${BLUE}  DEFAULT_NAMESPACE: $DEFAULT_NAMESPACE${NC}"
     echo -e "${BLUE}  LLAMA_MODEL_NAMESPACE: $LLAMA_MODEL_NAMESPACE${NC}"
     echo -e "${BLUE}  MODEL_CONFIG_SOURCE: $MODEL_CONFIG_SOURCE${NC}"
+    if [ "$MODEL_CONFIG_SOURCE" = "local" ]; then
+        if [ -n "$LLM_MODEL" ]; then
+            echo -e "${BLUE}  LLM_MODEL: $LLM_MODEL${NC}"
+        else
+            echo -e "${BLUE}  LLM_MODEL: $(get_default_model) (default)${NC}"
+        fi
+    fi
     echo -e "${BLUE}--------------------------------${NC}\n"
 
     start_port_forwards


### PR DESCRIPTION
Refactor model configuration generation to use shared script for both OpenShift deployment and local development

## Changes

- New shared script (`scripts/generate-model-config.sh`):
    - Single source of truth for model config generation
    - Dynamically merges base external models (OpenAI, Google, Anthropic) with specified LLM
    - Supports `--helm-format` flag for Helm deployment use case - _used by Makefile_
- Makefile updates:
    - Simplified `generate-model-config` target to call shared script with `--helm-format` param
    - Cleaner output and better error handling
- Local development improvements (`scripts/local-dev.sh`):
    - Added -l/L flag to specify LLM model _if a different model is used_ (default: `llama-3.2-3b-instruct`)
    - Uses shared script for consistent config generation
    - Refactored port-forwarding to use helper function for cleaner code
- Documentation updates:
    - Updated README.md with model config generation details
    - Enhanced DEV_GUIDE.md with architecture explanation and examples

## Checklist

- [x] Verify on the cluster - _for Makefile change_
- [ ] Update tests if applicable and run `pytest`
- [ ] Add screenshots (if applicable)
- [x] Update readme (if applicable)