### PR TITLE
Fixed model_config issue and local setup error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,8 +301,8 @@ install-metric-ui: namespace
 .PHONY: install-mcp-server
 install-mcp-server: namespace
 	@echo "Deploying MCP Server"
-	@echo "Generating model configuration for MCP Server (LLM=$(LLM)) if provided..."
-	@$(if $(LLM),$(MAKE) generate-model-config LLM=$(LLM),echo "LLM not set; skipping model config generation")
+	@echo "Generating model configuration for MCP Server (LLM=$(LLM))"
+	@$(MAKE) generate-model-config LLM=$(LLM)
 	@echo "  → [$(GEN_MODEL_CONFIG_PREFIX).output] contains the model config generation output"
 	@echo "Checking ClusterRole grafana-prometheus-reader for MCP..."
 	@if oc get clusterrole grafana-prometheus-reader > /dev/null 2>&1; then \
@@ -313,7 +313,7 @@ install-mcp-server: namespace
 			--set rbac.createGrafanaRole=false \
 			$(if $(MCP_SERVER_ROUTE_HOST),--set route.host='$(MCP_SERVER_ROUTE_HOST)',) \
 			$(if $(LLAMA_STACK_URL),--set llm.url='$(LLAMA_STACK_URL)',) \
-			$(if $(wildcard $(GEN_MODEL_CONFIG_PREFIX)-for_helm.yaml),-f $(GEN_MODEL_CONFIG_PREFIX)-for_helm.yaml,); \
+			-f $(GEN_MODEL_CONFIG_PREFIX)-for_helm.yaml; \
 	else \
 		echo "ClusterRole does not exist. Deploying and creating Grafana role..."; \
 		cd deploy/helm && helm upgrade --install $(MCP_SERVER_RELEASE_NAME) $(MCP_SERVER_CHART_PATH) -n $(NAMESPACE) \
@@ -322,7 +322,7 @@ install-mcp-server: namespace
 			--set rbac.createGrafanaRole=true \
 			$(if $(MCP_SERVER_ROUTE_HOST),--set route.host='$(MCP_SERVER_ROUTE_HOST)',) \
 			$(if $(LLAMA_STACK_URL),--set llm.url='$(LLAMA_STACK_URL)',) \
-			$(if $(wildcard $(GEN_MODEL_CONFIG_PREFIX)-for_helm.yaml),-f $(GEN_MODEL_CONFIG_PREFIX)-for_helm.yaml,); \
+			-f $(GEN_MODEL_CONFIG_PREFIX)-for_helm.yaml; \
 	fi
 
 .PHONY: install-rag

--- a/scripts/local-dev.sh
+++ b/scripts/local-dev.sh
@@ -52,7 +52,7 @@ parse_args() {
     DEFAULT_NAMESPACE=""
     LLAMA_MODEL_NAMESPACE=""
     MODEL_CONFIG_SOURCE="local"  # Default to local
-    LLM_MODEL=""  # Optional LLM model for config generation
+    LLM_MODEL=$(get_default_model)  # Optional LLM model for config generation
 
     # Parse standard arguments using getopts
     while getopts "n:N:m:M:c:C:l:L:" opt; do
@@ -321,11 +321,11 @@ start_local_services() {
 
 # Main execution
 main() {
-    parse_args "$@"
-    check_prerequisites
-
     # Source the shared script once (for model config generation and default model)
     source scripts/generate-model-config.sh
+
+    parse_args "$@"
+    check_prerequisites
 
     # Set cleanup trap only after successful prerequisite checks
     trap cleanup EXIT INT TERM
@@ -336,13 +336,7 @@ main() {
     echo -e "${BLUE}  DEFAULT_NAMESPACE: $DEFAULT_NAMESPACE${NC}"
     echo -e "${BLUE}  LLAMA_MODEL_NAMESPACE: $LLAMA_MODEL_NAMESPACE${NC}"
     echo -e "${BLUE}  MODEL_CONFIG_SOURCE: $MODEL_CONFIG_SOURCE${NC}"
-    if [ "$MODEL_CONFIG_SOURCE" = "local" ]; then
-        if [ -n "$LLM_MODEL" ]; then
-            echo -e "${BLUE}  LLM_MODEL: $LLM_MODEL${NC}"
-        else
-            echo -e "${BLUE}  LLM_MODEL: $(get_default_model) (default)${NC}"
-        fi
-    fi
+    echo -e "${BLUE}  LLM_MODEL: $LLM_MODEL${NC}"
     echo -e "${BLUE}--------------------------------${NC}\n"
 
     start_port_forwards


### PR DESCRIPTION
This PR fixes the following two issues:

1. A bug where the generated model configuration file was never being passed to Helm installations due to Make's evaluation timing.
   - Root cause:
     - `$(wildcard ...)` is evaluated at Makefile parse time (before any targets run)
     - The model config file is generated during the `install-mcp-server` target execution
     - Since the file doesn't exist at parse time, the wildcard always returns empty
     - Result: Helm never receives the `-f $(GEN_MODEL_CONFIG_PREFIX)-for_helm.yaml` flag, even though the file exists by the time Helm runs
2. When using default LLM with `local-dev.sh` and using `cluster` as config source, the `LLAMA_MODEL_SERVICE` service lookup was failing
   - Root cause:
     - When using default LLM, the variable `LLM` is not set to any value.
     - When `LLAMA_MODEL_SERVICE` service lookup is done, it uses `LLM` for label lookup
     - Without `LLM` being set, this lookup fails - this ONLY happens when using a default model when config source is set to `cluster`

**Fixes:**
1. Makefile (lines 316, 325):
   - Removed `$(if $(wildcard ...),...)` conditionals that were always false
   - Unconditionally pass `-f $(GEN_MODEL_CONFIG_PREFIX)-for_helm.yaml` to Helm
   - Safe because `generate-model-config` target runs earlier in the same target chain
2. Local Development Script (`scripts/local-dev.sh`):
   - Fixed initialization order: source generate-model-config.sh before parsing args
   - Set `LLM_MODEL` to default value using `get_default_model()` to prevent unset variable
   - Simplified model display logging

## Checklist

- [x] Verify on the cluster
- [ ] Update tests if applicable and run `pytest`
- [ ] Add screenshots (if applicable)
- [ ] Update readme (if applicable)